### PR TITLE
Syslog by default log all calls to sudo...

### DIFF
--- a/zabbix-zimbra/sudo_zbx-zimbra.conf
+++ b/zabbix-zimbra/sudo_zbx-zimbra.conf
@@ -1,1 +1,4 @@
-zabbix ALL=(zimbra) NOPASSWD:/opt/zimbra/bin/zmcontrol
+# Don't log every invocation of zmcontrol
+Cmnd_Alias ZIMBRA_BIN_ZABBIX = /opt/zimbra/bin/zmcontrol
+Defaults!ZIMBRA_BIN_ZABBIX !syslog
+zabbix ALL=(zimbra) NOPASSWD: ZIMBRA_BIN_ZABBIX


### PR DESCRIPTION
But if you run it from crontab your syslog becomes cluttered with useless information. This should remedie this situation.
Small warning if using older syslog there is no possibility to disable logging on alias level but on user level only :\
so this would be for older sudores file
Cmnd_Alias ZIMBRA_BIN_ZABBIX = /opt/zimbra/bin/zmcontrol
Defaults:zabbix !syslog
zabbix  ALL=(zimbra) NOPASSWD:  ZIMBRA_BIN_ZABBIX = /opt/zimbra/bin/zmcontrol
