### PR TITLE
Update zbx_zimbra.sh to avoid warning

### DIFF
--- a/zabbix-zimbra/zbx_zimbra.sh
+++ b/zabbix-zimbra/zbx_zimbra.sh
@@ -9,7 +9,7 @@
 # uncomment for debug
 #set -x
 
-COMMAND="sudo -u zimbra /opt/zimbra/bin/zmcontrol"
+COMMAND="sudo -H -u zimbra /opt/zimbra/bin/zmcontrol"
 FILE='/var/run/zabbix/zimbra_status'
 DISCOVER_FILE='/var/run/zabbix/zimbra_discover'
 


### PR DESCRIPTION
On Ubuntu 16.04, I get:
```
sudo -s -u zimbra /opt/zimbra/bin/zmcontrol
dpkg: warning: failed to open configuration file '/root/.dpkg.cfg' for reading: Permission denied
dpkg: warning: failed to open configuration file '/root/.dpkg.cfg' for reading: Permission denied
Release 8.8.6.GA.1906.UBUNTU16.64 UBUNTU16_64 FOSS edition.
/opt/zimbra/bin/zmcontrol [-v -h -H <host>] command [args]

        -v:     display version
        -h:     print usage statement
        -H:     Host name (localhost)

        Command in:
                restart                           Restart services
                shutdown                             Stop services
                start                               Start services
                startup                             Start services
                status                      Display service status
                stop                                 Stop services
```
To remove warning we must set HOME variable to target user's home dir.