### PR TITLE
Fix service status parsing

### DIFF
--- a/zabbix-zimbra/zbx_zimbra.sh
+++ b/zabbix-zimbra/zbx_zimbra.sh
@@ -81,7 +81,7 @@ case "$1" in
 
         fork_get_status &
 
-	STATUS="$(cat $FILE | grep "$check" | awk '{print $NF}')"
+	STATUS="$(cat $FILE | grep "`printf '\t'`$check " | awk '{print $NF}')"
 
 	if [ "$STATUS" != "Running" ]; then
 	  echo 0


### PR DESCRIPTION
If hostname contents service name, the value is not correct.

ex:
```
cat /var/run/zabbix/zimbra_status | grep "mta" | awk '{print $NF}'
srvmta001.mydomain.local
Running
```
